### PR TITLE
Fix attachments parsing after CSS class changes

### DIFF
--- a/services/web_parser.py
+++ b/services/web_parser.py
@@ -129,7 +129,12 @@ def extract_shortcuts(soup):
 
 
 def extract_attachments(soup):
-    links = soup.select("div.col-1 ul.list--Block--icons a")
+    # Updated selector: regeringen.se is transitioning from list--Block--icons to list--icons
+    # Use > to select only direct children of col-1, excluding nested islands
+    # Support both old and new class names during transition period
+    links_new = soup.select("div.col-1 > ul.list--icons a")
+    links_old = soup.select("div.col-1 > ul.list--Block--icons a")
+    links = links_new + links_old
     return [{"name": link.get_text(strip=True), "url": link["href"]} for link in links]
 
 


### PR DESCRIPTION
Såg att attachments inte kommer med korrekt sen någon gång i september. AI-kodat en patch så kan inte garantera att det är fixat eller att det är gjort på ett bra sätt men verkar funka.
## Problem
Regeringen.se har ändrat CSS-klasser från `list--Block--icons` till `list--icons` för bilagor, vilket orsakade att parsern missade PDF-filer på sidor med den nya klassen.

## Lösning
- Uppdaterat `extract_attachments()` att stödja både gamla och nya CSS-klasser
- Använder child combinator (`>`) för att endast välja direkta barn till `col-1`
- Kombinerar resultat från båda selektorerna för bakåtkompatibilitet

## Testat på
- SOU-sidor (ny klass: `list--icons`) ✓
- Propositioner (ny klass: `list--icons`) ✓
- Remisser (gammal klass: `list--Block--icons`) ✓

Alla sidtyper hämtar nu attachments korrekt.