### PR TITLE
Update attachments and shortcuts extraction

### DIFF
--- a/services/web_parser.py
+++ b/services/web_parser.py
@@ -129,7 +129,7 @@ def extract_shortcuts(soup):
 
 
 def extract_attachments(soup):
-    links_new = soup.select("div.col-1 > ul.list--icons a")
+    links_new = soup.select("div.col-1 > .list--icons a")
     links_old = soup.select("div.col-1 > ul.list--Block--icons a")
     links = links_new + links_old
     return [{"name": link.get_text(strip=True), "url": link["href"]} for link in links]

--- a/services/web_parser.py
+++ b/services/web_parser.py
@@ -116,16 +116,19 @@ def extract_metadata(soup):
 
 
 def extract_shortcuts(soup):
-    h2 = soup.find("h2", string=lambda s: s and "Genväg" in s)
+    h2_old = soup.find("h2", string=lambda s: s and "Genväg" in s)
+    shortcuts_old = [
+        shortcut for shortcut in h2_old.find_parent("div").select("a")
+    ] if h2_old else []
 
-    return (
-        [
-            {"name": a.get_text(strip=True), "url": a["href"]}
-            for a in h2.find_parent("div").select("a")
-        ]
-        if h2
-        else []
-    )
+    h2_new = soup.find("h2", string=lambda s: s and "remitteras" in s)
+    shortcuts_new = [
+        shortcut for shortcut in h2_new.find_parent("div").select("a")
+    ] if h2_new else []
+
+    shortcuts = shortcuts_old + shortcuts_new
+
+    return [{"name": shortcut.get_text(strip=True), "url": shortcut["href"]} for shortcut in shortcuts]
 
 
 def extract_attachments(soup):


### PR DESCRIPTION
This PR fixes some bugs in the extraction of attachments and shortcuts caused by some changes to regeringen.se

For example, the attachment on this page is currently not extracted: https://www.regeringen.se/rattsliga-dokument/statens-offentliga-utredningar/2025/12/sou-2025120/

The reason is that the code assumes that attachment links are in ul elements, but on this page it's in a div element. The changes here simply extracts all links instead.

For shortcuts, the issue is that they are not always indicated by "Genväg". Instead they can be indicated by "Dokumentet som remitteras" or "Dokument som remitteras". See for example https://www.regeringen.se/remisser/2025/10/remiss-av-promemorian-en-veterangard-for-vila-och-aterhamtning/ and https://regeringen.se/remisser/2026/02/remiss-av-revidering-av-koldioxidkraven-for-latta-fordon-och-av-eus-regler-om-fordonsmarkning/

This PR adds a find call to also look for "remitteras".